### PR TITLE
Fixed bug caused by a copy/paste error in Face3::get_closest_point_to

### DIFF
--- a/core/math/face3.cpp
+++ b/core/math/face3.cpp
@@ -393,7 +393,7 @@ Vector3 Face3::get_closest_point_to(const Vector3 &p_point) const {
 				s = CLAMP(numer / denom, 0.f, 1.f);
 				t = 1 - s;
 			} else {
-				s = CLAMP(-e / c, 0.f, 1.f);
+				s = CLAMP(-d / a, 0.f, 1.f);
 				t = 0.f;
 			}
 		} else {


### PR DESCRIPTION
I ran into weird behavior using Navigation.get_closest_point with a very simple mesh, and I believe I've found the root cause.  I haven't compiled this change, but I did pull the function out into a little test program where I confirmed it was acting wonky, and this was the fix.

s * edge0 = -d / a * edge0 = -edge0⋅v0 / (edge0⋅edge0) * edge0 = vector projection of -v0 onto edge0

By incorrectly using -e/c instead of -d/a, Face3::get_closest_point_to was returning the wrong point in certain cases.  Specifically, I noticed it returning vertex[0] when it should have been returning vertex[1].